### PR TITLE
Renamed ros_datacentre to mongodb_store

### DIFF
--- a/strands_hri_utils/package.xml
+++ b/strands_hri_utils/package.xml
@@ -45,14 +45,14 @@
   <build_depend>message_generation</build_depend>
   <build_depend>ros_mary_tts</build_depend>
   <build_depend>rospy</build_depend>
-  <build_depend>ros_datacentre</build_depend>
+  <build_depend>mongodb_store</build_depend>
   <build_depend>strands_visualise_speech</build_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>ros_mary_tts</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>ros_datacentre</run_depend>
+  <run_depend>mongodb_store</run_depend>
   <run_depend>strands_visualise_speech</run_depend>
 
 

--- a/strands_hri_utils/scripts/insert_dialogue.py
+++ b/strands_hri_utils/scripts/insert_dialogue.py
@@ -2,7 +2,7 @@
 
 import sys
 import std_msgs.msg
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 
 def loadDialogue(inputfile, dataset_name) :
     print "openning %s" %inputfile

--- a/strands_hri_utils/src/speak_webserver/webserver.py
+++ b/strands_hri_utils/src/speak_webserver/webserver.py
@@ -7,7 +7,7 @@ import roslib
 import rospy
 import actionlib
 import ros_mary_tts.msg
-import ros_datacentre.srv
+import mongodb_store.srv
 
 roslib.load_manifest('strands_hri_utils')
 
@@ -45,11 +45,11 @@ def save_line(id_value, text_value):
     rospy.set_param(param_prefix + id_value, text_value)
     try:
         save_service = rospy.ServiceProxy(
-            '/config_manager/save_param', ros_datacentre.srv.SetParam)
+            '/config_manager/save_param', mongodb_store.srv.SetParam)
         if not save_service.call(param_prefix + id_value):
-            rospy.logwarn('couldn\'t store config in ros_datacentre')
+            rospy.logwarn('couldn\'t store config in mongodb_store')
     except:
-        rospy.logwarn('couldn\'t access the ros_datacentre service')
+        rospy.logwarn('couldn\'t access the mongodb_store service')
 
 
 @app.route("/")

--- a/strands_interaction_behaviours/idle/src/engaged_server/engaged_server.py
+++ b/strands_interaction_behaviours/idle/src/engaged_server/engaged_server.py
@@ -5,7 +5,7 @@ import rospy
 import actionlib
 import strands_interaction_behaviours.msg
 import ros_mary_tts.msg
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 import std_msgs.msg
 from random import randint
 

--- a/strands_interaction_behaviours/idle/src/idle_server/idle_server.py
+++ b/strands_interaction_behaviours/idle/src/idle_server/idle_server.py
@@ -8,7 +8,7 @@ import std_msgs
 import geometry_msgs.msg
 import ros_mary_tts.msg
 import strands_gazing.msg
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 import std_msgs.msg
 
 import thread


### PR DESCRIPTION
This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.

Needs strands-project/ros_datacentre#76 to be merged first.
