### PR TITLE
Making human_aware_navigation more configurable

### DIFF
--- a/strands_human_aware_navigation/CMakeLists.txt
+++ b/strands_human_aware_navigation/CMakeLists.txt
@@ -1,21 +1,36 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(strands_human_aware_navigation)
 
-find_package(catkin REQUIRED COMPONENTS 
+find_package(catkin REQUIRED COMPONENTS
     bayes_people_tracker
-    geometry_msgs 
-    message_filters 
+    dynamic_reconfigure
+    geometry_msgs
+    message_filters
     roscpp
+)
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+generate_dynamic_reconfigure_options(
+  cfg/HumanAwareNavigation.cfg
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs
 )
 
 ###################################
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  CATKIN_DEPENDS 
+  CATKIN_DEPENDS
     bayes_people_tracker
-    geometry_msgs 
-    message_filters 
+    geometry_msgs
+    message_filters
     roscpp
 )
 

--- a/strands_human_aware_navigation/CMakeLists.txt
+++ b/strands_human_aware_navigation/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
     dynamic_reconfigure
     geometry_msgs
     message_filters
+    message_generation
     roscpp
 )
 

--- a/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
+++ b/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
@@ -22,7 +22,7 @@ gen.add("detection_angle",
     double_t, 0,
     "The in which humans are considered. +- detection_angle is used as a cone in front " + \
     "of the robot. E.g. 45 is treated as +45 and -45 to either side of the front. 180 form 360 degerees field of view.",
-    90.0, 0.1, 180.0)
+    80.0, 0.1, 180.0)
 
 gaze_type_enum = gen.enum([ gen.const("gaze",     int_t, 0, "gaze at people and nav goal"),
                            gen.const("no_gaze",     int_t, 1, "no gazing behaviour")],

--- a/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
+++ b/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
@@ -4,6 +4,25 @@ PACKAGE = "strands_human_aware_navigation"
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
+gen.add("timeout",
+    double_t, 0,
+    "The time of no human detections after which speed will be reset",
+    4.0, 1.0, 10)
+gen.add("max_dist",
+    double_t, 0,
+    "The maximum distance for a human detection to be considered close enough " + \
+    "for speed reduction. Speed is calculated for the interval between min_dist and max_dist.",
+    5.0, 1.0, 10.0)
+gen.add("min_dist",
+    double_t, 0,
+    "The minimum distance at which speed will reach 0. Speed is calculated " + \
+    "for the interval between min_dist and max_dist.",
+    1.5, 1.0, 9.0)
+gen.add("detection_angle",
+    double_t, 0,
+    "The in which humans are considered. +- detection_angle is used as a cone in front " + \
+    "of the robot. E.g. 45 is treated as +45 and -45 to either side of the front. 180 form 360 degerees field of view.",
+    90.0, 0.1, 180.0)
 
 gaze_type_enum = gen.enum([ gen.const("gaze",     int_t, 0, "gaze at people and nav goal"),
                            gen.const("no_gaze",     int_t, 1, "no gazing behaviour")],

--- a/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
+++ b/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+PACKAGE = "strands_human_aware_navigation"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gaze_type_enum = gen.enum([ gen.const("gaze",     int_t, 0, "gaze at people and nav goal"),
+                           gen.const("no_gaze",     int_t, 1, "no gazing behaviour")],
+                         "An enum to set the gazing type")
+
+gen.add("gaze_type", int_t, 0, "The gazing behaviour type", 0, 0, 1, edit_method=gaze_type_enum)
+
+exit(gen.generate(PACKAGE, "strands_human_aware_navigation", "HumanAwareNavigation"))

--- a/strands_human_aware_navigation/package.xml
+++ b/strands_human_aware_navigation/package.xml
@@ -21,7 +21,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_filters</build_depend>
-  <build_depend>message_generatio</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>move_base_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>

--- a/strands_human_aware_navigation/package.xml
+++ b/strands_human_aware_navigation/package.xml
@@ -21,6 +21,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_filters</build_depend>
+  <build_depend>message_generatio</build_depend>
   <build_depend>move_base_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
@@ -32,6 +33,7 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_filters</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>move_base_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>

--- a/strands_human_aware_navigation/package.xml
+++ b/strands_human_aware_navigation/package.xml
@@ -7,15 +7,16 @@
   <maintainer email="cdondrup@lincoln.ac.uk">Christian Dondrup</maintainer>
 
   <license>MIT</license>
-  
-  <url type="website">https://github.com/strands-project/strands_hri</url> 
-  
+
+  <url type="website">https://github.com/strands-project/strands_hri</url>
+
   <author email="cdondrup@lincoln.ac.uk">Christian Dondrup</author>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>bayes_people_tracker</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -24,7 +25,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>strands_gazing</build_depend>
-  
+
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>bayes_people_tracker</run_depend>

--- a/strands_human_aware_navigation/scripts/human_aware_navigation.py
+++ b/strands_human_aware_navigation/scripts/human_aware_navigation.py
@@ -8,7 +8,7 @@ from bayes_people_tracker.msg import PeopleTracker
 from strands_human_aware_navigation.cfg import HumanAwareNavigationConfig
 #from strands_head_orientation.srv import StartHeadAnalysis, StopHeadAnalysis
 import move_base_msgs.msg
-import thread
+import numpy as np
 import actionlib_msgs.msg
 import strands_gazing.msg
 
@@ -41,15 +41,20 @@ class DynamicVelocityReconfigure():
         )
         self.gazeClient.wait_for_server()
         rospy.loginfo("...done")
-        self.dyn_srv = DynServer(HumanAwareNavigationConfig, self.dyn_callback)
         rospy.loginfo("Reading move_base parameters")
         self.getCurrentSettings()
         rospy.loginfo("Reading parameters")
-        self.threshold = rospy.get_param(name+"/timeout", 4.0)
+
+        # Magic numbers overwritten in dyn_callback
+        self.threshold = 4.0
+        self.max_dist = 5.0
+        self.min_dist = 1.5
+        self.detection_angle = 90.0
+
+        self.dyn_srv = DynServer(HumanAwareNavigationConfig, self.dyn_callback)
+
         current_time = rospy.get_time()
         self.timeout = current_time + self.threshold
-        self.max_dist = rospy.get_param(name+"/max_dist", 5.0)
-        self.min_dist = rospy.get_param(name+"/min_dist", 1.5)
         rospy.loginfo("Creating action server.")
         self._as = actionlib.SimpleActionServer(
             self._action_name,
@@ -78,7 +83,11 @@ class DynamicVelocityReconfigure():
     def dyn_callback(self, config, level):
         if config["gaze_type"] == DynamicVelocityReconfigure.NO_GAZE:
             self.cancel_gaze_goal()
-        self.gaze_type = config["gaze_type"]
+        self.gaze_type       = config["gaze_type"]
+        self.threshold       = config["timeout"]
+        self.max_dist        = config["max_dist"]
+        self.min_dist        = config["min_dist"]
+        self.detection_angle = config["detection_angle"]
         return config
 
     def cancel_time_checker_cb(self, msg):
@@ -131,6 +140,11 @@ class DynamicVelocityReconfigure():
                     self.cancel_gaze_goal()
                     self._as.set_aborted()
 
+    def get_min_dist(self, data, angle):
+        rad = angle * (np.pi / 180.0)
+        distances = [x for idx, x in enumerate(data.distances) if data.angles[idx] >= -rad and data.angles[idx] <= rad]
+        return np.min(distances)
+
     def pedestrianCallback(self, pl):
         if not self._as.is_active():
             rospy.logdebug("No active goal. Unsubscribing.")
@@ -140,8 +154,9 @@ class DynamicVelocityReconfigure():
 
         if len(pl.poses) > 0:
             rospy.logdebug("Found people: ")
-            rospy.logdebug(" People distance: %s", pl.min_distance)
-            factor = pl.min_distance - self.min_dist
+            min_distance = self.get_min_dist(pl, self.detection_angle)
+            rospy.logdebug(" People distance: %s", min_distance)
+            factor = min_distance - self.min_dist
             factor = factor if factor > 0.0 else 0.0
             factor /= (self.max_dist - self.min_dist)
             factor = 1.0 if factor > 1.0 else factor

--- a/strands_human_aware_navigation/scripts/human_aware_navigation.py
+++ b/strands_human_aware_navigation/scripts/human_aware_navigation.py
@@ -23,7 +23,6 @@ class DynamicVelocityReconfigure():
         self._action_name = name
         self.fast = True
         self.gaze_type = DynamicVelocityReconfigure.GAZE
-        self.dyn_srv = DynServer(HumanAwareNavigationConfig, self.dyn_callback)
         rospy.loginfo("Creating dynamic reconfigure client")
         self.client = dynamic_reconfigure.client.Client(
             "/move_base/DWAPlannerROS"
@@ -42,6 +41,7 @@ class DynamicVelocityReconfigure():
         )
         self.gazeClient.wait_for_server()
         rospy.loginfo("...done")
+        self.dyn_srv = DynServer(HumanAwareNavigationConfig, self.dyn_callback)
         rospy.loginfo("Reading move_base parameters")
         self.getCurrentSettings()
         rospy.loginfo("Reading parameters")

--- a/strands_human_aware_navigation/scripts/human_aware_navigation.py
+++ b/strands_human_aware_navigation/scripts/human_aware_navigation.py
@@ -3,7 +3,9 @@
 import rospy
 import actionlib
 import dynamic_reconfigure.client
+from dynamic_reconfigure.server import Server as DynServer
 from bayes_people_tracker.msg import PeopleTracker
+from strands_human_aware_navigation.cfg import HumanAwareNavigationConfig
 #from strands_head_orientation.srv import StartHeadAnalysis, StopHeadAnalysis
 import move_base_msgs.msg
 import thread
@@ -14,10 +16,14 @@ import strands_gazing.msg
 class DynamicVelocityReconfigure():
     "A calss to reconfigure the velocity of the DWAPlannerROS."
 
+    GAZE, NO_GAZE = range(2)
+
     def __init__(self, name):
         rospy.loginfo("Starting %s", name)
         self._action_name = name
         self.fast = True
+        self.gaze_type = DynamicVelocityReconfigure.GAZE
+        self.dyn_srv = DynServer(HumanAwareNavigationConfig, self.dyn_callback)
         rospy.loginfo("Creating dynamic reconfigure client")
         self.client = dynamic_reconfigure.client.Client(
             "/move_base/DWAPlannerROS"
@@ -69,8 +75,25 @@ class DynamicVelocityReconfigure():
             self.cancel_time_checker_cb
         )
 
+    def dyn_callback(self, config, level):
+        if config["gaze_type"] == DynamicVelocityReconfigure.NO_GAZE:
+            self.cancel_gaze_goal()
+        self.gaze_type = config["gaze_type"]
+        return config
+
     def cancel_time_checker_cb(self, msg):
         self.last_cancel_time = rospy.get_rostime()
+
+    def send_gaze_goal(self, topic):
+        if self.gaze_type == DynamicVelocityReconfigure.GAZE:
+            gaze_goal = strands_gazing.msg.GazeAtPoseGoal()
+            gaze_goal.runtime_sec = 0
+            gaze_goal.topic_name = topic
+            self.gazeClient.send_goal(gaze_goal)
+
+    def cancel_gaze_goal(self):
+        if self.gaze_type == DynamicVelocityReconfigure.GAZE:
+            self.gazeClient.cancel_all_goals()
 
     def getCurrentSettings(self):
         max_vel_x = round(rospy.get_param("/move_base/DWAPlannerROS/max_vel_x"), 2)
@@ -105,7 +128,7 @@ class DynamicVelocityReconfigure():
                 except rospy.ServiceException as exc:
                     rospy.logerr("Caught service exception: %s", exc)
                     self.baseClient.cancel_all_goals()
-                    self.gazeClient.cancel_all_goals()
+                    self.cancel_gaze_goal()
                     self._as.set_aborted()
 
     def pedestrianCallback(self, pl):
@@ -129,10 +152,7 @@ class DynamicVelocityReconfigure():
             rot_speed = round(rot_speed, 2)
             rospy.logdebug("Calculated rotaional speed: %s", rot_speed)
             if not trans_speed == self.fast_param['max_vel_x']:  # and not rot_speed == self.fast_param['max_rot_vel']:
-                gaze_goal = strands_gazing.msg.GazeAtPoseGoal()
-                gaze_goal.runtime_sec = 0
-                gaze_goal.topic_name = "/upper_body_detector/closest_bounding_box_centre"
-                self.gazeClient.send_goal(gaze_goal)
+                self.send_gaze_goal("/upper_body_detector/closest_bounding_box_centre")
                 self.slow_param = {'max_vel_x': trans_speed, 'max_trans_vel': trans_speed}  #, 'max_rot_vel' : rot_speed}
                 try:
                     print 'making it slow'
@@ -145,10 +165,7 @@ class DynamicVelocityReconfigure():
         elif rospy.get_time() > self.timeout:
             rospy.logdebug("Not found any pedestrians:")
             if not self.fast:
-                gaze_goal = strands_gazing.msg.GazeAtPoseGoal()
-                gaze_goal.runtime_sec = 0
-                gaze_goal.topic_name = "/pose_extractor/pose"
-                self.gazeClient.send_goal(gaze_goal)
+                self.send_gaze_goal("/pose_extractor/pose")
                 self.resetSpeed()
                 self.fast = True
             else:
@@ -164,10 +181,7 @@ class DynamicVelocityReconfigure():
             5
         )
         self._goal = goal
-        gaze_goal = strands_gazing.msg.GazeAtPoseGoal()
-        gaze_goal.runtime_sec = 0
-        gaze_goal.topic_name = "/pose_extractor/pose"
-        self.gazeClient.send_goal(gaze_goal)
+        self.send_gaze_goal("/pose_extractor/pose")
         #self.getCurrentSettings()
         rospy.logdebug("Received goal:\n%s", self._goal)
         self.resetSpeed()
@@ -184,14 +198,14 @@ class DynamicVelocityReconfigure():
         if rospy.get_rostime()-self.last_cancel_time < rospy.Duration(1):
             rospy.logdebug("Cancelled execution of goal:\n%s", self._goal)
             self.baseClient.cancel_all_goals()
-            self.gazeClient.cancel_all_goals()
+            self.cancel_gaze_goal()
             self.resetSpeed()
         self._as.set_preempted()
 
     def moveBaseThread(self, goal):
         ret = self.moveBase(goal)
         self.resetSpeed()
-        self.gazeClient.cancel_all_goals()
+        self.cancel_gaze_goal()
         #try:
             #s = rospy.ServiceProxy('/stop_head_analysis', StopHeadAnalysis)
             #s()

--- a/strands_human_aware_navigation/scripts/human_aware_navigation.py
+++ b/strands_human_aware_navigation/scripts/human_aware_navigation.py
@@ -143,7 +143,7 @@ class DynamicVelocityReconfigure():
     def get_min_dist(self, data, angle):
         rad = angle * (np.pi / 180.0)
         distances = [x for idx, x in enumerate(data.distances) if data.angles[idx] >= -rad and data.angles[idx] <= rad]
-        return np.min(distances)
+        return np.min(distances) if len(distances) else 1000.0
 
     def pedestrianCallback(self, pl):
         if not self._as.is_active():


### PR DESCRIPTION
Addresses: https://github.com/strands-project/aaf_deployment/issues/56
- Now using dynamic reconfigure for all parameters but topic names.
- Gaze control can now be toggled using dynamic reconfigure
- Human detections are only considered in a cone in front of the robot. Default size +-80 degrees. Can be dynamically reconfigured.

Needs: https://github.com/strands-project/strands_perception_people/pull/153 to work properly
