### PR TITLE
Removing generate messages macro from human_aware_navigation

### DIFF
--- a/strands_human_aware_navigation/CMakeLists.txt
+++ b/strands_human_aware_navigation/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(catkin REQUIRED COMPONENTS
     dynamic_reconfigure
     geometry_msgs
     message_filters
-    message_generation
     roscpp
 )
 
@@ -16,12 +15,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 generate_dynamic_reconfigure_options(
   cfg/HumanAwareNavigation.cfg
-)
-
-## Generate added messages and services with any dependencies listed here
-generate_messages(
-  DEPENDENCIES
-  std_msgs
 )
 
 ###################################

--- a/strands_human_aware_navigation/package.xml
+++ b/strands_human_aware_navigation/package.xml
@@ -21,7 +21,6 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_filters</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>move_base_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
@@ -33,7 +32,6 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_filters</run_depend>
-  <run_depend>message_runtime</run_depend>
   <run_depend>move_base_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>


### PR DESCRIPTION
This is apparently not necessary for dyn reconf and only leads to a cmake warning.
