### PR TITLE
Setting rot vel to 0 if trans vel is below 0.05.

### DIFF
--- a/strands_human_aware_navigation/scripts/human_aware_navigation.py
+++ b/strands_human_aware_navigation/scripts/human_aware_navigation.py
@@ -14,7 +14,7 @@ import strands_gazing.msg
 
 
 class DynamicVelocityReconfigure():
-    "A calss to reconfigure the velocity of the DWAPlannerROS."
+    "A class to reconfigure the velocity of the DWAPlannerROS."
 
     GAZE, NO_GAZE = range(2)
 
@@ -169,7 +169,11 @@ class DynamicVelocityReconfigure():
             rospy.logdebug("Calculated rotaional speed: %s", rot_speed)
             if not trans_speed == self.fast_param['max_vel_x']:  # and not rot_speed == self.fast_param['max_rot_vel']:
                 self.send_gaze_goal("/upper_body_detector/closest_bounding_box_centre")
-                self.slow_param = {'max_vel_x': trans_speed, 'max_trans_vel': trans_speed}  #, 'max_rot_vel' : rot_speed}
+                self.slow_param = {
+                    'max_vel_x': trans_speed,
+                    'max_trans_vel': trans_speed,
+                    'max_rot_vel': 0.0 if trans_speed < 0.05 else self.fast_param["max_rot_vel"]
+                }
                 try:
                     print 'making it slow'
                     self.client.update_configuration(self.slow_param)


### PR DESCRIPTION
This prevents the robot from spinning on the spot when there is humans around.
Tested on Linda. Needs testing in the wild.

This treats the rotation as a binary state because we experienced the robot driving into obstacles if the rot vel is reduced gradually. With this it is only set to 0 if there are humans at a distance to the robot ~`min_distance`, ans it keeps its default value if not.
