### PR TITLE
Changing default and min values for some of the params

### DIFF
--- a/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
+++ b/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
@@ -12,17 +12,17 @@ gen.add("max_dist",
     double_t, 0,
     "The maximum distance for a human detection to be considered close enough " + \
     "for speed reduction. Speed is calculated for the interval between min_dist and max_dist.",
-    5.0, 1.0, 10.0)
+    4.0, 1.0, 10.0)
 gen.add("min_dist",
     double_t, 0,
     "The minimum distance at which speed will reach 0. Speed is calculated " + \
     "for the interval between min_dist and max_dist.",
-    1.5, 1.0, 9.0)
+    1.0, 0.0, 9.0)
 gen.add("detection_angle",
     double_t, 0,
     "The in which humans are considered. +- detection_angle is used as a cone in front " + \
     "of the robot. E.g. 45 is treated as +45 and -45 to either side of the front. 180 form 360 degerees field of view.",
-    80.0, 0.1, 180.0)
+    45.0, 0.1, 180.0)
 
 gaze_type_enum = gen.enum([ gen.const("gaze",     int_t, 0, "gaze at people and nav goal"),
                            gen.const("no_gaze",     int_t, 1, "no gazing behaviour")],


### PR DESCRIPTION
Min distance can now be 0.0. The problem is that, the robot will stop moving before the min distance is reached, because the transitional velocity will be too low for the planner to find a valid plan. This PR sets more conservative default values as well to allow for easier testing and not having the robot stop because of @santosj all the time ;)

During the pre-deployment, we have to find a suitable set for AAF.
