### PR TITLE
Adding ability of reconfiguring movebase and human_aware together

### DIFF
--- a/strands_human_aware_navigation/CMakeLists.txt
+++ b/strands_human_aware_navigation/CMakeLists.txt
@@ -4,6 +4,7 @@ project(strands_human_aware_navigation)
 find_package(catkin REQUIRED COMPONENTS
     bayes_people_tracker
     dynamic_reconfigure
+    dwa_local_planner
     geometry_msgs
     message_filters
     roscpp
@@ -37,12 +38,19 @@ include_directories(
 )
 
 add_executable(human_aware_cmd_vel src/main.cpp)
+add_executable(dwa_dyn_wrapper src/dwa_dyn.cpp)
 
 add_dependencies(human_aware_cmd_vel
     ${catkin_EXPORTED_TARGETS}
 )
+add_dependencies(dwa_dyn_wrapper
+    ${catkin_EXPORTED_TARGETS}
+)
 
 target_link_libraries(human_aware_cmd_vel
+  ${catkin_LIBRARIES}
+)
+target_link_libraries(dwa_dyn_wrapper
   ${catkin_LIBRARIES}
 )
 
@@ -55,8 +63,12 @@ install(PROGRAMS
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(TARGETS human_aware_cmd_vel
+install(TARGETS human_aware_cmd_vel dwa_dyn_wrapper
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
+++ b/strands_human_aware_navigation/cfg/HumanAwareNavigation.cfg
@@ -23,6 +23,18 @@ gen.add("detection_angle",
     "The in which humans are considered. +- detection_angle is used as a cone in front " + \
     "of the robot. E.g. 45 is treated as +45 and -45 to either side of the front. 180 form 360 degerees field of view.",
     45.0, 0.1, 180.0)
+gen.add("max_vel_x",
+    double_t, 0,
+    "The maximum x velocity of the DWAPlannerROS.",
+    0.55, -float("inf"), float("inf"))
+gen.add("max_trans_vel",
+    double_t, 0,
+    "The maximum translational velocity of the DWAPlannerROS.",
+    0.55, -float("inf"), float("inf"))
+gen.add("max_rot_vel",
+    double_t, 0,
+    "The maximum rotation velocity of the DWAPlannerROS.",
+    1.0, 0.0, float("inf"))
 
 gaze_type_enum = gen.enum([ gen.const("gaze",     int_t, 0, "gaze at people and nav goal"),
                            gen.const("no_gaze",     int_t, 1, "no gazing behaviour")],

--- a/strands_human_aware_navigation/launch/human_aware_navigation.launch
+++ b/strands_human_aware_navigation/launch/human_aware_navigation.launch
@@ -1,0 +1,9 @@
+<launch>
+  <arg name="machine" default="localhost" />
+  <arg name="user" default="" />
+
+  <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER)" user="$(arg user)" default="true"/>
+  
+  <node pkg="strands_human_aware_navigation" type="human_aware_navigation.py" name="human_aware_navigation" output="screen" respawn="true"/>
+  <node pkg="strands_human_aware_navigation" type="dwa_dyn_wrapper" name="DWAPlannerROS_dyn_wrapper" output="screen" respawn="true"/>
+</launch>

--- a/strands_human_aware_navigation/package.xml
+++ b/strands_human_aware_navigation/package.xml
@@ -19,6 +19,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>bayes_people_tracker</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>dwa_local_planner</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>move_base_msgs</build_depend>
@@ -30,6 +31,7 @@
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>bayes_people_tracker</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>dwa_local_planner</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>move_base_msgs</run_depend>

--- a/strands_human_aware_navigation/src/dwa_dyn.cpp
+++ b/strands_human_aware_navigation/src/dwa_dyn.cpp
@@ -1,0 +1,84 @@
+#include <ros/ros.h>
+
+#include <dynamic_reconfigure/server.h>
+#include <dynamic_reconfigure/Reconfigure.h>
+#include <dynamic_reconfigure/Config.h>
+#include <dwa_local_planner/DWAPlannerConfig.h>
+
+bool setup_ = false;
+dwa_local_planner::DWAPlannerConfig default_config_;
+
+
+void callback(dwa_local_planner::DWAPlannerConfig &config, uint32_t level) {
+    if (setup_ && config.restore_defaults) {
+        config = default_config_;
+        config.restore_defaults = false;
+    }
+    if ( ! setup_) {
+        default_config_ = config;
+        setup_ = true;
+    }
+
+    dynamic_reconfigure::ReconfigureRequest srv_req;
+    dynamic_reconfigure::ReconfigureResponse srv_resp;
+    dynamic_reconfigure::DoubleParameter double_param;
+    dynamic_reconfigure::BoolParameter bool_param;
+    dynamic_reconfigure::IntParameter int_param;
+    dynamic_reconfigure::Config conf, human_conf;
+
+    // Incredibly terrible C++ dynamic reconfigure client emulation...
+    bool_param.name   = "prune_plan";              bool_param.value = config.prune_plan;                conf.bools.push_back(bool_param);
+    bool_param.name   = "restore_defaults";        bool_param.value = config.restore_defaults;          conf.bools.push_back(bool_param);
+    bool_param.name   = "use_dwa";                 bool_param.value = config.use_dwa;                   conf.bools.push_back(bool_param);
+
+    int_param.name    = "vth_samples";             int_param.value = config.vth_samples;                conf.ints.push_back(int_param);
+    int_param.name    = "vx_samples";              int_param.value = config.vx_samples;                 conf.ints.push_back(int_param);
+    int_param.name    = "vy_samples";              int_param.value = config.vy_samples;                 conf.ints.push_back(int_param);
+
+    double_param.name = "acc_limit_trans";         double_param.value = config.acc_limit_trans;         conf.doubles.push_back(double_param);
+    double_param.name = "acc_lim_theta";           double_param.value = config.acc_lim_theta;           conf.doubles.push_back(double_param);
+    double_param.name = "acc_lim_x";               double_param.value = config.acc_lim_x;               conf.doubles.push_back(double_param);
+    double_param.name = "acc_lim_y";               double_param.value = config.acc_lim_y;               conf.doubles.push_back(double_param);
+    double_param.name = "angular_sim_granularity"; double_param.value = config.angular_sim_granularity; conf.doubles.push_back(double_param);
+    double_param.name = "forward_point_distance";  double_param.value = config.forward_point_distance;  conf.doubles.push_back(double_param);
+    double_param.name = "goal_distance_bias";      double_param.value = config.goal_distance_bias;      conf.doubles.push_back(double_param);
+    double_param.name = "max_rot_vel";             double_param.value = config.max_rot_vel;             conf.doubles.push_back(double_param); human_conf.doubles.push_back(double_param);
+    double_param.name = "max_scaling_factor";      double_param.value = config.max_scaling_factor;      conf.doubles.push_back(double_param);
+    double_param.name = "max_trans_vel";           double_param.value = config.max_trans_vel;           conf.doubles.push_back(double_param); human_conf.doubles.push_back(double_param);
+    double_param.name = "max_vel_x";               double_param.value = config.max_vel_x;               conf.doubles.push_back(double_param); human_conf.doubles.push_back(double_param);
+    double_param.name = "max_vel_y";               double_param.value = config.max_vel_y;               conf.doubles.push_back(double_param);
+    double_param.name = "min_rot_vel";             double_param.value = config.min_rot_vel;             conf.doubles.push_back(double_param);
+    double_param.name = "min_trans_vel";           double_param.value = config.min_trans_vel;           conf.doubles.push_back(double_param);
+    double_param.name = "min_vel_x";               double_param.value = config.min_vel_x;               conf.doubles.push_back(double_param);
+    double_param.name = "min_vel_y";               double_param.value = config.min_vel_y;               conf.doubles.push_back(double_param);
+    double_param.name = "occdist_scale";           double_param.value = config.occdist_scale;           conf.doubles.push_back(double_param);
+    double_param.name = "oscillation_reset_angle"; double_param.value = config.oscillation_reset_angle; conf.doubles.push_back(double_param);
+    double_param.name = "oscillation_reset_dist";  double_param.value = config.oscillation_reset_dist;  conf.doubles.push_back(double_param);
+    double_param.name = "path_distance_bias";      double_param.value = config.path_distance_bias;      conf.doubles.push_back(double_param);
+    double_param.name = "rot_stopped_vel";         double_param.value = config.rot_stopped_vel;         conf.doubles.push_back(double_param);
+    double_param.name = "scaling_speed";           double_param.value = config.scaling_speed;           conf.doubles.push_back(double_param);
+    double_param.name = "sim_granularity";         double_param.value = config.sim_granularity;         conf.doubles.push_back(double_param);
+    double_param.name = "sim_time";                double_param.value = config.sim_time;                conf.doubles.push_back(double_param);
+    double_param.name = "stop_time_buffer";        double_param.value = config.stop_time_buffer;        conf.doubles.push_back(double_param);
+    double_param.name = "trans_stopped_vel";       double_param.value = config.trans_stopped_vel;       conf.doubles.push_back(double_param);
+    double_param.name = "xy_goal_tolerance";       double_param.value = config.xy_goal_tolerance;       conf.doubles.push_back(double_param);
+    double_param.name = "yaw_goal_tolerance";      double_param.value = config.yaw_goal_tolerance;      conf.doubles.push_back(double_param);
+
+    srv_req.config = conf;
+    ros::service::call("/move_base/DWAPlannerROS/set_parameters", srv_req, srv_resp);
+    srv_req.config = human_conf;
+    ros::service::call("/human_aware_navigation/set_parameters", srv_req, srv_resp);
+}
+
+int main(int argc, char **argv) {
+    ros::init(argc, argv, "DWAPlannerROS_dyn_wrapper");
+
+    dynamic_reconfigure::Server<dwa_local_planner::DWAPlannerConfig> server(ros::NodeHandle("/human_aware_navigation/DWAPlannerROS"));
+    dynamic_reconfigure::Server<dwa_local_planner::DWAPlannerConfig>::CallbackType f;
+
+    f = boost::bind(&callback, _1, _2);
+    server.setCallback(f);
+
+    ros::spin();
+    return 0;
+}


### PR DESCRIPTION
Problem description: the parameters in human_aware_navigation where "hard coded" (only updated from param server when restarted) due to a particular error of dynamic reconfigure. Sometimes it fails for no obvious reason and there is no use in retrying it since it fails continuously. In such cases the speed would not have been reset properly and at the next node when updating the default max speeds, the human_aware would take the lower ones and never recover to the full speed. Hence #86.

Arising problem due to new features in navigation: the speed can now (or soon) be defined on edges in the topo map. This would need to reconfigure move_base. This would rob it of the flexibility of replacing the move_base action with human_aware_navigation on edges because it would still try to reconfigure move_base but not human_aware. There now is a very ugly node, didn't find a better solution (only one dyn calback in python, no namspaces in python), that works on `/human_aware_navigation/DWAPlannerROS` and then reconfigures `/move_base/DWAPlannerROS` and human_aware_navigation itself. Therefore, topo nav can now rely on on `<move_action>/DWAPlannerROS` to be reconfigurable.

closes #86 
