### PR TITLE
Using empty action to start bellbot.

### DIFF
--- a/bellbot_action_server/action/bellbot.action
+++ b/bellbot_action_server/action/bellbot.action
@@ -1,8 +1,8 @@
 # Define the goal
-int32  mode # 1=multi-runs-multi-goals, 2=multi-runs-single-goal, 3=single-run-single-goal
-string starting_waypoint_name # Waypoint the bellbot gui will be started at.  
-string preselected_goal
-string text
+#int32  mode # 1=multi-runs-multi-goals, 2=multi-runs-single-goal, 3=single-run-single-goal
+#string starting_waypoint_name # Waypoint the bellbot gui will be started at.  
+#string preselected_goal
+#string text
 ---
 # Define the result
 # empty for now as there is no direct result of the bellbot.

--- a/bellbot_action_server/scripts/bellbot_server.py
+++ b/bellbot_action_server/scripts/bellbot_server.py
@@ -12,13 +12,16 @@ from bellbot_action_server.msg import *
 from strands_executive_msgs.srv import IsTaskInterruptible
 
 from bellbot_action_server.bellbot_state_machine import BellbotStateMachine
+from collections import namedtuple
+from std_msgs.msg import String
 
+Goal = namedtuple("Goal", "mode starting_waypoint_name preselected_goal text")
 
 class BellbotServer(object):
     # create messages that are used to publish feedback/result
     _feedback = bellbot_action_server.msg.bellbotFeedback()
     _result   = bellbot_action_server.msg.bellbotResult()
-    
+
     def __init__(self, name):
         self._action_name = name
         self._as = actionlib.SimpleActionServer(self._action_name, bellbot_action_server.msg.bellbotAction, execute_cb=self.execute_cb, auto_start = False)
@@ -36,7 +39,7 @@ class BellbotServer(object):
         return True
         # rospy.loginfo('No, I will never stop')
         # return False
-        
+
     def is_preempt_requested(self):
         return self._as.is_preempt_requested()
 
@@ -46,10 +49,18 @@ class BellbotServer(object):
     def cleanup(self):
         subprocess.call(["pkill", "florence"])
 
-    def execute_cb(self, goal):
+    def execute_cb(self, empty):
+        # No user input given anyway. hard coding mode and text. Taking current node as start and goal.
+        # Scheduler ensures we are at the right goal before executing this.
+        current_node = rospy.wait_for_message("/current_node", String)
+        goal = Goal(
+            mode=1, #Could be param but no other mode implemented.
+            starting_waypoint_name=current_node.data,
+            preselected_goal=current_node.data,
+            text="Henry im Haus der Barmherzigkeit"
+        )
+        rospy.loginfo('Goal struct: %s', goal)
 
-        rospy.loginfo('Received goal request: %s', goal)
-        
         # helper variables
         r = rospy.Rate(1)
         self.success = True
@@ -58,7 +69,7 @@ class BellbotServer(object):
         self.bellbot_sm = BellbotStateMachine()
 
         # set userdata: pass the whole goal
-        self.bellbot_sm.set_sm_userdata(goal)        
+        self.bellbot_sm.set_sm_userdata(goal)
         # run the bellbot state machine with or without introspection server
         # outcome = bellbot_sm.execute_sm()
 
@@ -67,7 +78,7 @@ class BellbotServer(object):
 
         #outcome = self.bellbot_sm.execute_sm_with_introspection()
         r.sleep()
-        
+
         while self.bellbot_sm.get_sm().is_running() and not self.bellbot_sm.get_sm().preempt_requested():
             # check that preempt has not been requested by the client
             if self._as.is_preempt_requested() or self._stop:
@@ -81,21 +92,21 @@ class BellbotServer(object):
             r.sleep()
 
         sm = self.bellbot_sm.get_sm()
-        
+
         if self.success:
             rospy.loginfo('%s: Succeeded' % self._action_name)
-        
+
         smach_thread.join()
 
         self._as.set_succeeded(self._result)
 
-        
+
 
 if __name__ == '__main__':
     rospy.init_node('bellbot_action_server')
     bellbot = BellbotServer(rospy.get_name())
     rospy.spin()
-    
+
     #r = rospy.Rate(1)
     #while not bellbot.is_preempt_requested():
     #    r.sleep()


### PR DESCRIPTION
To make scheduling and general usage easier.
- `mode` is now hard coded to `1` but there is no other mode anyway.
- starting and goal waypoint are set from `/current_node`. The scheduler ensures the robot to be at the correct node before the execute callback is called.
- The `text` is now also hard coded.

spyder was also gracious enough to remove nasty trailing white spaces ;)
