### PR TITLE
[bellbot_voice] Adding ability to incorporate text published on topics.

### DIFF
--- a/bellbot_action_server/conf/bellbot_voice.yaml
+++ b/bellbot_action_server/conf/bellbot_voice.yaml
@@ -13,8 +13,8 @@ WaitingForGoal:
     start: "Waiting For Goal start"
     end: "Waiting For Goal end"
 Guiding:
-    start: "Guiding start"
-    end: "Guiding end"
+    start: "Guiding start to $(topic /current_node)"
+    end: "Guiding ended at $(topic /current_node)"
 WaitingForFeedback:
     start: "Waiting For Feedback start"
     end: "Waiting For Feedback end"

--- a/bellbot_action_server/scripts/voice_output.py
+++ b/bellbot_action_server/scripts/voice_output.py
@@ -68,7 +68,6 @@ class Manager(object):
 
     def call_topic(self, regex):
         topic = regex.group(0).split(' ')[1][:-1]
-        print topic
         return rospy.wait_for_message(topic, String, True).data
 
 


### PR DESCRIPTION
This adds the functionality that text from topics publishing string objects can be integrated into the text output, e.g.:

"I am at $(topic /current_node)" would be replaced to "I am at Reception". The publishing topic should be latched because this call is blocking.

This feature allows to publish the description on how to get to a station from the lift and incorporate it into the text output, e.g. "$(topic /my_description). Thank you for using the bellbot." Would translate to whatever is publish on the description topic plus the added string. See config file for usage example. 
