### PR TITLE
[hrsi_representation] Adding the ability of only publishing the latest qtc state.

### DIFF
--- a/hrsi_representation/cfg/OnlineQTCCreator.cfg
+++ b/hrsi_representation/cfg/OnlineQTCCreator.cfg
@@ -8,8 +8,9 @@ gen = ParameterGenerator()
 gen.add("quantisation_factor", double_t, 0, "The quintisation for the creation of 0-satest in m",       .1, 0,    10)
 gen.add("distance_threshold",  double_t, 0, "The distance threshold for qtcbc transitions in m",     122.0, 0,    10)
 gen.add("smoothing_rate",      double_t, 0, "The smoothing rate in s",                                  .3, 0,    10)
-gen.add("validate",            bool_t,   0, "Only create valid transtions",                           True)
-gen.add("no_collapse",         bool_t,   0, "Do not collapse similar adjacent states. If qtc_type is set to qtcbc this is always True.",  False)
+gen.add("validate",            bool_t,   0, "Only create valid transtions. Always false if prune_buffer is true.", True)
+gen.add("no_collapse",         bool_t,   0, "Do not collapse similar adjacent states. Always false if prune_buffer is true.", False)
+gen.add("prune_buffer",        bool_t,   0, "Never keep more than the last element in buffer to reduce load on qsr_lib. ATTENTION: This disables no_collapse and validate!", False)
 
 qtc_type_enum = gen.enum([ gen.const("qtcb",     int_t, 0, "1D QTC_B"),
                            gen.const("qtcc",     int_t, 1, "2D QTC_C"),


### PR DESCRIPTION
The dynamically reconfigurable parameter `prune_buffer`, if set to `true` - default `false` to not change the default behaviour, removes every entry but the last from the buffer after the creation and publishing of a new qtc state. This reduces the load on the QSR lib and allows to only get the current qtc state if you don't care about the preceding ones, e.g. for reactive systems.

The buffer pruning has two side effects: validation does not work any more as the system is agnostic of the previous state and `no_collapse` also does not have any effect. Hence, when setting `prune_buffer` to true, `validate` and `no_collapse` will be set to `false`.

This PR also includes two bugfixes:
1. **Major**: When no transformation could be found the thread returned instead of just using continue to try again. This would stop the whole process. Also, instead of waiting for the transform to become available, the latest common timestamp is used. Waiting led to significant delays between receiving and publishing.
1. **Minor**: The `robot_pose` is now initialised with and empty `geometry_msgs/Pose` instead of `None`. In the rare case of observing a human before getting the robot's pose, this would have otherwise led to a crash; Can only happen in simulation.
