### PR TITLE
[Velocity Costmaps] Catching identity change during interaction

### DIFF
--- a/hrsi_velocity_costmaps/scripts/velocity_costmap_server.py
+++ b/hrsi_velocity_costmaps/scripts/velocity_costmap_server.py
@@ -67,8 +67,11 @@ class VelocityCostmapServer(object):
                 "velocity": vels[ppl.uuids.index(e.uuid)]
             } for e in qtc.qtc
         }
-        element = data_buffer[ppl.uuids[ppl.distances.index(ppl.min_distance)]] # Only taking the closest person for now
-        self.publish_closest_person_marker(ppl.poses[ppl.distances.index(ppl.min_distance)], ppl.header.frame_id)
+        try:
+            element = data_buffer[ppl.uuids[ppl.distances.index(ppl.min_distance)]] # Only taking the closest person for now
+            self.publish_closest_person_marker(ppl.poses[ppl.distances.index(ppl.min_distance)], ppl.header.frame_id)
+        except KeyError:
+            return
         qtc = element["qtc"].split(',')
         self.cc.publish(
             angle=element["angle"],


### PR DESCRIPTION
If a person changes their tracking id while the best model is classified and the belief generated, the UUID for costmap generation is not the same as in the current list of tracked people any more. If this is the case, the velo map is just not created.
