### PR TITLE
Adding an action dispatcher to allow for arbitrary edge actions

### DIFF
--- a/han_action_dispatcher/CMakeLists.txt
+++ b/han_action_dispatcher/CMakeLists.txt
@@ -1,0 +1,160 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(han_action_dispatcher)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  actionlib
+  actionlib_msgs
+  dynamic_reconfigure
+  move_base_msgs
+  rospy
+  std_msgs
+  strands_human_aware_navigation
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   actionlib_msgs#   move_base_msgs#   std_msgs
+# )
+
+generate_dynamic_reconfigure_options(
+  cfg/HanActionDispatcher.cfg
+)
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES han_action_dispatcher
+#  CATKIN_DEPENDS actionlib actionlib_msgs dynamic_reconfigure move_base_msgs rospy std_msgs strands_human_aware_navigation
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(had_dwa_dyn_wrapper src/dwa_dyn.cpp)
+
+add_dependencies(had_dwa_dyn_wrapper
+    ${catkin_EXPORTED_TARGETS}
+)
+
+target_link_libraries(had_dwa_dyn_wrapper
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+install(PROGRAMS
+  scripts/action_dispatcher.py
+  scripts/dwa_param_loader.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS had_dwa_dyn_wrapper
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY conf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/han_action_dispatcher/cfg/HanActionDispatcher.cfg
+++ b/han_action_dispatcher/cfg/HanActionDispatcher.cfg
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+PACKAGE = "han_action_disptacher"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+gen.add("use_default",  bool_t,   0, "Use the default action for human-aware navigation",  True)
+
+exit(gen.generate(PACKAGE, PACKAGE, "HanActionDispatcher"))

--- a/han_action_dispatcher/conf/actions.yaml
+++ b/han_action_dispatcher/conf/actions.yaml
@@ -1,0 +1,7 @@
+han_actions:
+    han_adapt_speed:
+        action: human_aware_navigation
+    han_vc_corridor:
+        action: None
+    han_vc_junction:
+        action: None

--- a/han_action_dispatcher/launch/han_action_dispatcher.launch
+++ b/han_action_dispatcher/launch/han_action_dispatcher.launch
@@ -1,0 +1,28 @@
+<launch>
+  <arg name="machine" default="localhost" />
+  <arg name="user" default="" />
+  <arg name="use_default" default="true" />
+  <arg name="default_action" default="human_aware_navigation" />
+  <arg name="with_site_movebase_params" default="false"/>
+  <arg name="site_movebase_params" default=""/>
+
+  <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER)" user="$(arg user)" default="true"/>
+  
+  <node pkg="han_action_dispatcher" type="action_dispatcher.py" name="han_action_dispatcher" output="screen" respawn="true">
+    <param name="use_default" value="$(arg use_default)" type="bool"/>
+    <param name="default_action" value="$(arg default_action)" type="string"/>
+    <rosparam file="$(find han_action_dispatcher)/conf/actions.yaml" command="load"/>
+  </node>
+  <node pkg="han_action_dispatcher" type="had_dwa_dyn_wrapper" name="DWAPlannerROS_dyn_wrapper_action_dispatcher" output="screen" respawn="true">
+    <param name="default_action" value="$(arg default_action)" type="string"/>
+  </node>
+  <node pkg="han_action_dispatcher" type="dwa_param_loader.py" name="dwa_param_loader_default" output="screen">
+    <param name="param_file" value="$(find strands_movebase)/strands_movebase_params/dwa_planner_ros.yaml" type="string"/>
+  </node>
+  <!-- THIS SHOULD STAY LAST, so that sites can override anything. -->
+  <group if="$(arg with_site_movebase_params)">
+    <node pkg="han_action_dispatcher" type="dwa_param_loader.py" name="dwa_param_loader_site_params" output="screen">
+      <param name="param_file" value="$(arg site_movebase_params)" type="string"/>
+    </node>
+  </group>
+</launch>

--- a/han_action_dispatcher/package.xml
+++ b/han_action_dispatcher/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package>
+  <name>han_action_dispatcher</name>
+  <version>0.1.1</version>
+  <description>The han_action_dispatcher package</description>
+
+  <maintainer email="cdondrup@gmail.com">Christian Dondrup</maintainer>
+  <license>MIT</license>
+  <author email="cdondrup@gmail.com">Christian Dondrup</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>move_base_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>strands_human_aware_navigation</build_depend>
+
+  <run_depend>actionlib</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>move_base_msgs</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>strands_human_aware_navigation</run_depend>
+
+  <export/>
+</package>

--- a/han_action_dispatcher/scripts/action_dispatcher.py
+++ b/han_action_dispatcher/scripts/action_dispatcher.py
@@ -10,8 +10,6 @@ from han_action_dispatcher.cfg import HanActionDispatcherConfig
 
 
 class ActionDispatcher(object):
-    OLD, NEW = range(2)
-    
     def __init__(self, name):
         rospy.loginfo("Starting %s" % name)
         self.client = None

--- a/han_action_dispatcher/scripts/action_dispatcher.py
+++ b/han_action_dispatcher/scripts/action_dispatcher.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+from actionlib.simple_action_server import SimpleActionServer
+from actionlib.simple_action_client import SimpleActionClient
+from move_base_msgs.msg import MoveBaseAction
+from dynamic_reconfigure.server import Server as DynServer
+from han_action_dispatcher.cfg import HanActionDispatcherConfig
+
+
+class ActionDispatcher(object):
+    OLD, NEW = range(2)
+    
+    def __init__(self, name):
+        rospy.loginfo("Starting %s" % name)
+        self.client = None
+        action_list = rospy.get_param("han_action_dispatcher")["han_actions"]
+        self.default_action = rospy.get_param("~default_action")
+        self.dyn_srv = DynServer(HanActionDispatcherConfig, self.dyn_callback)
+        self.servers = {}
+        for a in action_list.items():
+            name = a[0]
+            self.servers[name] = SimpleActionServer(
+                name, 
+                MoveBaseAction,
+                execute_cb=(lambda x: lambda msg: self.execute_cb(msg, x[0], x[1]["action"]))(a),
+                auto_start=False
+            )
+            self.servers[name].register_preempt_callback(self.preempt_cb)
+            self.servers[name].start()
+        rospy.loginfo("done")
+        
+    def execute_cb(self, msg, name, action):
+        a = action if not self.use_default else self.default_action
+        self.client = SimpleActionClient(a, MoveBaseAction)
+        rospy.logdebug("Waiting for action server:" + a)
+        self.client.wait_for_server()
+        rospy.logdebug("Sending goal to:" + a)
+        self.client.send_goal_and_wait(msg)
+        self.servers[name].set_succeeded()
+        self.client = None
+        
+    def preempt_cb(self):
+        if self.client != None:
+            self.client.cancel_all_goals()
+            self.client = None
+        
+    def dyn_callback(self, config, level):
+        self.use_default = config["use_default"]
+        return config
+        
+        
+if __name__ == "__main__":
+    rospy.init_node("han_action_dispatcher")
+    ActionDispatcher(rospy.get_name())
+    rospy.spin()

--- a/han_action_dispatcher/scripts/dwa_param_loader.py
+++ b/han_action_dispatcher/scripts/dwa_param_loader.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+import rosparam
+
+
+class ActionDispatcher(object):
+    OLD, NEW = range(2)
+    
+    def __init__(self, name):
+        rospy.loginfo("Starting %s" % name)
+        a_list = rospy.get_param("han_action_dispatcher")["han_actions"]
+        param_file = rospy.get_param("~param_file")
+        for a in a_list.keys():
+            rosparam.load_file(param_file, a, True)
+        rospy.loginfo("done")
+        
+        
+if __name__ == "__main__":
+    rospy.init_node("dwa_param_loader")
+    ActionDispatcher(rospy.get_name())
+    

--- a/han_action_dispatcher/scripts/dwa_param_loader.py
+++ b/han_action_dispatcher/scripts/dwa_param_loader.py
@@ -5,9 +5,7 @@ import rospy
 import rosparam
 
 
-class ActionDispatcher(object):
-    OLD, NEW = range(2)
-    
+class ParamLoader(object):
     def __init__(self, name):
         rospy.loginfo("Starting %s" % name)
         a_list = rospy.get_param("han_action_dispatcher")["han_actions"]
@@ -19,5 +17,5 @@ class ActionDispatcher(object):
         
 if __name__ == "__main__":
     rospy.init_node("dwa_param_loader")
-    ActionDispatcher(rospy.get_name())
+    ParamLoader(rospy.get_name())
     

--- a/han_action_dispatcher/src/dwa_dyn.cpp
+++ b/han_action_dispatcher/src/dwa_dyn.cpp
@@ -1,0 +1,115 @@
+#include <ros/ros.h>
+
+#include <dynamic_reconfigure/server.h>
+#include <dynamic_reconfigure/Reconfigure.h>
+#include <dynamic_reconfigure/Config.h>
+#include <dwa_local_planner/DWAPlannerConfig.h>
+
+#include <XmlRpcValue.h>
+
+#include <map>
+#include <vector>
+#include <string>
+
+bool setup_ = false;
+dwa_local_planner::DWAPlannerConfig default_config_;
+
+
+void callback(dwa_local_planner::DWAPlannerConfig &config, uint32_t level, std::string action, std::string default_action) {
+    ROS_INFO("CALLED");
+    if (setup_ && config.restore_defaults) {
+        config = default_config_;
+        config.restore_defaults = false;
+    }
+    if ( ! setup_) {
+        default_config_ = config;
+        setup_ = true;
+    }
+
+    dynamic_reconfigure::ReconfigureRequest srv_req;
+    dynamic_reconfigure::ReconfigureResponse srv_resp;
+    dynamic_reconfigure::DoubleParameter double_param;
+    dynamic_reconfigure::BoolParameter bool_param;
+    dynamic_reconfigure::IntParameter int_param;
+    dynamic_reconfigure::Config conf;
+
+    // Incredibly terrible C++ dynamic reconfigure client emulation...
+    bool_param.name   = "prune_plan";              bool_param.value = config.prune_plan;                conf.bools.push_back(bool_param);
+    bool_param.name   = "restore_defaults";        bool_param.value = config.restore_defaults;          conf.bools.push_back(bool_param);
+    bool_param.name   = "use_dwa";                 bool_param.value = config.use_dwa;                   conf.bools.push_back(bool_param);
+
+    int_param.name    = "vth_samples";             int_param.value = config.vth_samples;                conf.ints.push_back(int_param);
+    int_param.name    = "vx_samples";              int_param.value = config.vx_samples;                 conf.ints.push_back(int_param);
+    int_param.name    = "vy_samples";              int_param.value = config.vy_samples;                 conf.ints.push_back(int_param);
+
+    double_param.name = "acc_limit_trans";         double_param.value = config.acc_limit_trans;         conf.doubles.push_back(double_param);
+    double_param.name = "acc_lim_theta";           double_param.value = config.acc_lim_theta;           conf.doubles.push_back(double_param);
+    double_param.name = "acc_lim_x";               double_param.value = config.acc_lim_x;               conf.doubles.push_back(double_param);
+    double_param.name = "acc_lim_y";               double_param.value = config.acc_lim_y;               conf.doubles.push_back(double_param);
+    double_param.name = "angular_sim_granularity"; double_param.value = config.angular_sim_granularity; conf.doubles.push_back(double_param);
+    double_param.name = "forward_point_distance";  double_param.value = config.forward_point_distance;  conf.doubles.push_back(double_param);
+    double_param.name = "goal_distance_bias";      double_param.value = config.goal_distance_bias;      conf.doubles.push_back(double_param);
+    double_param.name = "max_rot_vel";             double_param.value = config.max_rot_vel;             conf.doubles.push_back(double_param);
+    double_param.name = "max_scaling_factor";      double_param.value = config.max_scaling_factor;      conf.doubles.push_back(double_param);
+    double_param.name = "max_trans_vel";           double_param.value = config.max_trans_vel;           conf.doubles.push_back(double_param);
+    double_param.name = "max_vel_x";               double_param.value = config.max_vel_x;               conf.doubles.push_back(double_param);
+    double_param.name = "max_vel_y";               double_param.value = config.max_vel_y;               conf.doubles.push_back(double_param);
+    double_param.name = "min_rot_vel";             double_param.value = config.min_rot_vel;             conf.doubles.push_back(double_param);
+    double_param.name = "min_trans_vel";           double_param.value = config.min_trans_vel;           conf.doubles.push_back(double_param);
+    double_param.name = "min_vel_x";               double_param.value = config.min_vel_x;               conf.doubles.push_back(double_param);
+    double_param.name = "min_vel_y";               double_param.value = config.min_vel_y;               conf.doubles.push_back(double_param);
+    double_param.name = "occdist_scale";           double_param.value = config.occdist_scale;           conf.doubles.push_back(double_param);
+    double_param.name = "oscillation_reset_angle"; double_param.value = config.oscillation_reset_angle; conf.doubles.push_back(double_param);
+    double_param.name = "oscillation_reset_dist";  double_param.value = config.oscillation_reset_dist;  conf.doubles.push_back(double_param);
+    double_param.name = "path_distance_bias";      double_param.value = config.path_distance_bias;      conf.doubles.push_back(double_param);
+    double_param.name = "rot_stopped_vel";         double_param.value = config.rot_stopped_vel;         conf.doubles.push_back(double_param);
+    double_param.name = "scaling_speed";           double_param.value = config.scaling_speed;           conf.doubles.push_back(double_param);
+    double_param.name = "sim_granularity";         double_param.value = config.sim_granularity;         conf.doubles.push_back(double_param);
+    double_param.name = "sim_time";                double_param.value = config.sim_time;                conf.doubles.push_back(double_param);
+    double_param.name = "stop_time_buffer";        double_param.value = config.stop_time_buffer;        conf.doubles.push_back(double_param);
+    double_param.name = "trans_stopped_vel";       double_param.value = config.trans_stopped_vel;       conf.doubles.push_back(double_param);
+    double_param.name = "xy_goal_tolerance";       double_param.value = config.xy_goal_tolerance;       conf.doubles.push_back(double_param);
+    double_param.name = "yaw_goal_tolerance";      double_param.value = config.yaw_goal_tolerance;      conf.doubles.push_back(double_param);
+
+    srv_req.config = conf;
+    ros::service::call("/"+default_action+"/DWAPlannerROS/set_parameters", srv_req, srv_resp); // Always reconfigure default action, can't hurt
+    if(action.compare("None")!=0 && action.compare(default_action)!=0)
+        ros::service::call("/"+action+"/DWAPlannerROS/set_parameters", srv_req, srv_resp);
+}
+
+std::map<std::string, std::string> parseParams(ros::NodeHandle n) {
+    std::map<std::string, std::string> actions;
+
+    XmlRpc::XmlRpcValue a_list;
+    n.getParam("han_action_dispatcher", a_list);
+    ROS_ASSERT(a_list.getType() == XmlRpc::XmlRpcValue::TypeStruct);
+    ROS_INFO_STREAM("Action list: " << a_list["han_actions"]);
+    ROS_ASSERT(a_list["han_actions"].getType() == XmlRpc::XmlRpcValue::TypeStruct);
+    for(XmlRpc::XmlRpcValue::ValueStruct::const_iterator it = a_list["han_actions"].begin(); it != a_list["han_actions"].end(); ++it) {
+       ROS_INFO_STREAM("Found action: " << (std::string)(it->first) << " ==> " << a_list["han_actions"][it->first]);
+       actions[(std::string)(it->first)] = (std::string)(a_list["han_actions"][it->first]["action"]);
+    }
+    return actions;
+}
+
+int main(int argc, char **argv) {
+    ros::init(argc, argv, "DWAPlannerROS_dyn_wrapper_action_dispatcher");
+    ros::NodeHandle nh("");
+    std::map<std::string, std::string> actions = parseParams(nh);
+    ros::NodeHandle pnh("~");
+    std::string default_action = "human_aware_navigation";
+    pnh.param("default_action", default_action, default_action);
+
+    std::vector<dynamic_reconfigure::Server<dwa_local_planner::DWAPlannerConfig>* > servers;
+    for(std::map<std::string, std::string>::iterator it = actions.begin(); it != actions.end(); ++it) {
+        ROS_INFO_STREAM("Creating dynamic reconfigure server: " << it->first);
+        dynamic_reconfigure::Server<dwa_local_planner::DWAPlannerConfig> *server = new dynamic_reconfigure::Server<dwa_local_planner::DWAPlannerConfig>(ros::NodeHandle("/"+it->first+"/DWAPlannerROS"));
+        dynamic_reconfigure::Server<dwa_local_planner::DWAPlannerConfig>::CallbackType f;
+        f = boost::bind(&callback, _1, _2, (std::string)it->second, default_action);
+        server->setCallback(f);
+        servers.push_back(server);
+    }
+
+    ros::spin();
+    return 0;
+}


### PR DESCRIPTION
In order to use the new human-aware navigation, edges need to be identified as, e.g. corridor, junction, etc. so I know which models to load. To do so without changing the topological map definition, this dispatcher can be used. In the config file, you can define the new action name that goes on the edge and which real action it is supposed to call. For now, this is pretty pointless because it basically always calls `human_aware_navigation` under different names. In future this will be extended with additional parameters that can be added to the actual action before it is called, example:

han_vc_corridor(goal) -> new_human_aware(goal, models_to_load, ...)

this is not implemented yet because this PR is just meant as a starting point so we can change edge actions.

Also, this dispatcher can be dynamically configured to only use the default action, i.e. `human_aware_navigation` so we can turn off the new one without having to change the map or restart components.

This package also contains a dynamic reconfigure wrapper for all the new actions that calls the dynamic reconfigure wrapper of the underlying action which in turn calls the move_base dynamic reconfigure \o/
Nasty stuff but works for me in simulation. To be tested next week.

Addressing https://github.com/strands-project/aaf_deployment/issues/352

Currently the three different edge types are:

```
han_adapt_speed -> old style adaptive speed
han_vc_corridor -> velocity costmaps for corridors
han_vc_junction -> velocity costmaps for junctions
```

But, as I said, this can easily be extended using the config file.

@Jailander @marc-hanheide 